### PR TITLE
Layerdepth

### DIFF
--- a/src/node/GameObject.cs
+++ b/src/node/GameObject.cs
@@ -44,7 +44,7 @@ namespace Utils {
     protected int collisionLayer = 0;
 
     // other vars
-    public int layerDepth = 0;
+    public float drawDepth = 0;
     public Color drawColor = Color.White;
 
 
@@ -74,7 +74,7 @@ namespace Utils {
           ImageOrigin,
           spriteScale,
           SpriteEffects.None,
-          layerDepth
+          drawDepth
         );
       }
 

--- a/src/utils/Animation.cs
+++ b/src/utils/Animation.cs
@@ -1,7 +1,7 @@
 using System;
 using Microsoft.Xna.Framework;
 
-// Ive made a change
+// Ive made a change again
 
 namespace Utils {
 

--- a/src/utils/Animation.cs
+++ b/src/utils/Animation.cs
@@ -1,8 +1,6 @@
 using System;
 using Microsoft.Xna.Framework;
 
-// Ive made a change again
-
 namespace Utils {
 
   public enum AnimationType {


### PR DESCRIPTION
Changes `int GameObject.layerDepth` to `float GameObject.drawDepth`. 

In the client app we can use `SpriteBatch.Draw(SpriteSortMode.BackToFront,...)` which will use the object's `drawDepth` to change the draw order (0.0f being closest, and 1.0f being farthest).

I think `drawDepth` is more readable, as the concept of layers is already being used for collision detection. 