### PR TITLE
Horizontal alignment

### DIFF
--- a/src/node/TextObject.cs
+++ b/src/node/TextObject.cs
@@ -82,7 +82,11 @@ namespace Utils {
 
     public static Font BaseFont;
 
-    public TextObject(Font font = null, int x = 0, int y = 0, string text = null) {
+    public TextObject(Font font) : this(null, 0, 0, HorizontalAlignment.LEFT, VerticalAlignment.TOP, font) { }
+
+    public TextObject(string text, int x, int y) : this(text, x, y, HorizontalAlignment.LEFT, VerticalAlignment.TOP, null) { }
+
+    public TextObject(string text, int x, int y, HorizontalAlignment horizontalAlignment, VerticalAlignment verticalAlignment, Font font) {
       _font = font;
       if (_font == null) {
         _font = BaseFont;
@@ -94,6 +98,8 @@ namespace Utils {
 
       X = x;
       Y = y;
+      _horizontalAlignment = horizontalAlignment;
+      _verticalAlignment = verticalAlignment;
       if (text != null) {
         SetText(text);
       }

--- a/src/node/TextObject.cs
+++ b/src/node/TextObject.cs
@@ -12,6 +12,11 @@ namespace Utils {
     CENTER
   }
 
+  public enum HorizontalAlignment {
+    LEFT,
+    CENTER
+  }
+
   public class TextObject : Node {
 
     private Font _font;
@@ -49,6 +54,21 @@ namespace Utils {
       }
       set {
         _verticalAlignment = value;
+
+        Bounds.Rect = new Rectangle(0, 0, 10, _font.lineHeight);
+
+        if (_text != null) {
+          SetText(_text);
+        }
+      }
+    }
+    private HorizontalAlignment _horizontalAlignment;
+    public HorizontalAlignment HorizontalAlignment {
+      get {
+        return _horizontalAlignment;
+      }
+      set {
+        _horizontalAlignment = value;
 
         Bounds.Rect = new Rectangle(0, 0, 10, _font.lineHeight);
 
@@ -162,11 +182,12 @@ namespace Utils {
 
       Bounds.Rect = new Rectangle(0, 0, maxWidth, maxHeight);
 
-      if (_verticalAlignment == VerticalAlignment.CENTER) {
-        TextOrigin = new Vector2(0, Bounds.Rect.Height / 2);
+      TextOrigin = Vector2.Zero;
+      if (_horizontalAlignment == HorizontalAlignment.CENTER) {
+        TextOrigin.X = Bounds.Rect.Width / 2;
       }
-      else if (_verticalAlignment == VerticalAlignment.TOP) {
-        TextOrigin = new Vector2(0, 0);
+      if (_verticalAlignment == VerticalAlignment.CENTER) {
+        TextOrigin.Y = Bounds.Rect.Height / 2;
       }
     }
   }


### PR DESCRIPTION
Usage:
```
TextObject textObject;
textObject.HorizontalAlignment = HorizontalAlignment.CENTER;
textObject.VerticalAlignment = VerticalAlignment.CENTER;
```

- Added alignments to constructor
- Rearranged constructor parameters
- Added 2 constructor overloads
- Setting _verticalAlignment and _horizontalAlignment directly in the constructor, since setting VerticalAlignment or HorizontalAlignment will result in extra calls to SetText();