### PR TITLE
add camera from monocle

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,12 +1,11 @@
 {
   // Change "mono" to "clr" for 64-bit .NET Framework debugging on Windows.
   // (See: https://github.com/OmniSharp/omnisharp-vscode/wiki/Desktop-.NET-Framework)
-
   "version": "0.2.0",
   "configurations": [
     {
       "name": "Launch",
-      "type": "mono",
+      "type": "clr",
       "request": "launch",
       "program": "${workspaceFolder}/bin/Debug/test_game.exe",
       "cwd": "${workspaceFolder}",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,30 +4,64 @@
     {
       "label": "Restore Project",
       "type": "shell",
-      "command": "msbuild /t:restore",
+      "osx": {
+        "command": "msbuild /t:restore",
+      },
+      "windows": {
+        "command": "MSBuild.exe //t:restore",
+      },
       "group": "build",
       "problemMatcher": "$msCompile"
     },
     {
       "label": "Clean Project",
       "type": "shell",
-      "command": "msbuild /t:clean /p:configuration=Debug ; msbuild /t:clean /p:configuration=Release",
+      "osx": {
+        "command": "msbuild /t:clean /p:configuration=Debug ; msbuild /t:clean /p:configuration=Release",
+      },
+      "windows": {
+        "command": "MsBuild.exe //t:clean //p:configuration=Debug ; MSBuild.exe //t:clean //p:configuration=Release",
+      },
       "group": "build",
       "problemMatcher": "$msCompile"
     },
     {
       "label": "Build (Debug)",
       "type": "shell",
-      "command": "msbuild",
-      "args": ["/p:configuration=Debug", "/t:build"],
+      "osx": {
+        "command": "msbuild",
+        "args": [
+          "/p:configuration=Debug",
+          "/t:build"
+        ]
+      },
+      "windows": {
+        "command": "MSBuild.exe",
+        "args": [
+          "//p:configuration=Debug",
+          "//t:build"
+        ],
+      },
       "group": "build",
       "problemMatcher": "$msCompile"
     },
     {
       "label": "Build (Release)",
       "type": "shell",
-      "command": "msbuild",
-      "args": ["/p:configuration=Release", "/t:build"],
+      "osx": {
+        "command": "msbuild",
+        "args": [
+          "/p:configuration=Release",
+          "/t:build"
+        ]
+      },
+      "windows": {
+        "command": "MSBuild.exe",
+        "args": [
+          "//p:configuration=Release",
+          "//t:build"
+        ],
+      },
       "group": "build",
       "problemMatcher": "$msCompile"
     },
@@ -43,7 +77,10 @@
       },
       "windows": {
         "command": "cmd",
-        "args": ["/k", "${workspaceFolder}/bin/Debug/test_game.exe"]
+        "args": [
+          "/k",
+          "${workspaceFolder}/bin/Debug/test_game.exe"
+        ]
       },
       "dependsOn": "Build (Debug)",
       "problemMatcher": "$msCompile"
@@ -57,7 +94,10 @@
       },
       "windows": {
         "command": "cmd",
-        "args": ["/k", "${workspaceFolder}/bin/Release/test_game.exe"]
+        "args": [
+          "/k",
+          "${workspaceFolder}/bin/Release/test_game.exe"
+        ]
       },
       "dependsOn": "Build (Release)",
       "problemMatcher": "$msCompile"

--- a/src/utils/Camera.cs
+++ b/src/utils/Camera.cs
@@ -1,0 +1,249 @@
+
+//   m o n O c l e
+
+//    e n g i n e
+
+
+// Copyright (c) 2012-2014 Matt Thorson
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+
+
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using System;
+
+namespace Utils {
+
+  public class Camera {
+
+    private Matrix matrix = Matrix.Identity;
+    private Matrix inverse = Matrix.Identity;
+    private bool changed;
+
+    private Vector2 position = Vector2.Zero;
+    private Vector2 zoom = Vector2.One;
+    private Vector2 origin = Vector2.Zero;
+    private float angle = 0;
+
+    public Viewport Viewport;
+
+    // public Camera() {
+    //   Viewport = new Viewport();
+    //   Viewport.Width = Engine.Width;
+    //   Viewport.Height = Engine.Height;
+    //   UpdateMatrices();
+    // }
+
+    public Camera(int width, int height) {
+      Viewport = new Viewport();
+      Viewport.Width = width;
+      Viewport.Height = height;
+      UpdateMatrices();
+    }
+
+    public override string ToString() {
+      return "Camera:\n\tViewport: { " + Viewport.X + ", " + Viewport.Y + ", " + Viewport.Width + ", " + Viewport.Height +
+        " }\n\tPosition: { " + position.X + ", " + position.Y +
+        " }\n\tOrigin: { " + origin.X + ", " + origin.Y +
+        " }\n\tZoom: { " + zoom.X + ", " + zoom.Y +
+        " }\n\tAngle: " + angle;
+    }
+
+    private void UpdateMatrices() {
+      matrix = Matrix.Identity *
+        Matrix.CreateTranslation(new Vector3(-new Vector2((int)Math.Floor(position.X), (int)Math.Floor(position.Y)), 0)) *
+        Matrix.CreateRotationZ(angle) *
+        Matrix.CreateScale(new Vector3(zoom, 1)) *
+        Matrix.CreateTranslation(new Vector3(new Vector2((int)Math.Floor(origin.X), (int)Math.Floor(origin.Y)), 0));
+
+      inverse = Matrix.Invert(matrix);
+
+      changed = false;
+    }
+
+    public void CopyFrom(Camera other) {
+      position = other.position;
+      origin = other.origin;
+      angle = other.angle;
+      zoom = other.zoom;
+      changed = true;
+    }
+
+    public Matrix Matrix {
+      get {
+        if (changed)
+          UpdateMatrices();
+        return matrix;
+      }
+    }
+
+    public Matrix Inverse {
+      get {
+        if (changed)
+          UpdateMatrices();
+        return inverse;
+      }
+    }
+
+    public Vector2 Position {
+      get { return position; }
+      set {
+        changed = true;
+        position = value;
+      }
+    }
+
+    public Vector2 Origin {
+      get { return origin; }
+      set {
+        changed = true;
+        origin = value;
+      }
+    }
+
+    public float X {
+      get { return position.X; }
+      set {
+        changed = true;
+        position.X = value;
+      }
+    }
+
+    public float Y {
+      get { return position.Y; }
+      set {
+        changed = true;
+        position.Y = value;
+      }
+    }
+
+    public float Width {
+      get { return Viewport.Width; }
+    }
+
+    public float Height {
+      get { return Viewport.Height; }
+    }
+
+    public float Zoom {
+      get { return zoom.X; }
+      set {
+        changed = true;
+        zoom.X = zoom.Y = value;
+      }
+    }
+
+    public float Angle {
+      get { return angle; }
+      set {
+        changed = true;
+        angle = value;
+      }
+    }
+
+    public float Left {
+      get {
+        if (changed)
+          UpdateMatrices();
+        return Vector2.Transform(Vector2.Zero, Inverse).X;
+      }
+
+      set {
+        if (changed)
+          UpdateMatrices();
+        X = Vector2.Transform(Vector2.UnitX * value, Matrix).X;
+      }
+    }
+
+    public float Right {
+      get {
+        if (changed)
+          UpdateMatrices();
+        return Vector2.Transform(Vector2.UnitX * Viewport.Width, Inverse).X;
+      }
+
+      set {
+        throw new NotImplementedException();
+      }
+    }
+
+    public float Top {
+      get {
+        if (changed)
+          UpdateMatrices();
+        return Vector2.Transform(Vector2.Zero, Inverse).Y;
+      }
+
+      set {
+        if (changed)
+          UpdateMatrices();
+        Y = Vector2.Transform(Vector2.UnitY * value, Matrix).Y;
+      }
+    }
+
+    public float Bottom {
+      get {
+        if (changed)
+          UpdateMatrices();
+        return Vector2.Transform(Vector2.UnitY * Viewport.Height, Inverse).Y;
+      }
+
+      set {
+        throw new NotImplementedException();
+      }
+    }
+
+    /*
+     *  Utils
+     */
+
+    public void CenterOrigin() {
+      origin = new Vector2((float)Viewport.Width / 2, (float)Viewport.Height / 2);
+      changed = true;
+    }
+
+    public void RoundPosition() {
+      position.X = (float)Math.Round(position.X);
+      position.Y = (float)Math.Round(position.Y);
+      changed = true;
+    }
+
+    public Vector2 ScreenToCamera(Vector2 position) {
+      return Vector2.Transform(position, Inverse);
+    }
+
+    public Vector2 CameraToScreen(Vector2 position) {
+      return Vector2.Transform(position, Matrix);
+    }
+
+    public void Approach(Vector2 position, float ease) {
+      Position += (position - Position) * ease;
+    }
+
+    public void Approach(Vector2 position, float ease, float maxDistance) {
+      Vector2 move = (position - Position) * ease;
+      if (move.Length() > maxDistance)
+        Position += Vector2.Normalize(move) * maxDistance;
+      else
+        Position += move;
+    }
+  }
+}

--- a/utils.csproj
+++ b/utils.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>net46</TargetFramework>
-		<Platforms>x64</Platforms>
+		<!-- change the platform target if necessary for your system -->
+		<PlatformTarget>x64</PlatformTarget>
 	</PropertyGroup>
 	<PropertyGroup>
 		<EnableDefaultItems>false</EnableDefaultItems>
@@ -17,9 +18,10 @@
   </ItemGroup>
 
 	<!-- Reference SharpFont project -->
+	<!-- change the path directory if necessary for your system -->
 	<ItemGroup>
 		<Reference Include="SharpFont">
-			<HintPath>../_fnalibs/osx/SharpFont.dll</HintPath>
+			<HintPath>../_fnalibs/x64/SharpFont.dll</HintPath>
 		</Reference>
 	</ItemGroup>
 

--- a/utils.csproj
+++ b/utils.csproj
@@ -34,6 +34,7 @@
 		<Compile Include="src/node/Sprite.cs" />
 		
 		<Compile Include="src/utils/Animation.cs" />
+		<Compile Include="src/utils/Camera.cs" />
 		<Compile Include="src/utils/Collision.cs" />
 		<Compile Include="src/utils/Font.cs" />
 		<Compile Include="src/utils/Hex.cs" />


### PR DESCRIPTION
Adds in camera support from the Monocle engine.

Usage:

GameControler.cs
```c#
// constructor
Camera = new Camera(Constants.Screen.VirtualWidth, Constants.Screen.VirtualHeight);

//draw, first sprite batch call
SpriteBatch.Begin(
        SpriteSortMode.BackToFront,
        BlendState.AlphaBlend,
        SamplerState.PointClamp,
        DepthStencilState.Default,
        RasterizerState.CullNone,
        null,
        Camera.Matrix
);
```
The camera should use the virtual width and height, not the actual client sizes.

Example.cs
```
GC.Camera.Position = Player1.Position - CameraOriginVector;

if (GC.Camera.Position.X < 0) {
     GC.Camera.X = 0;
}
else if (GC.Camera.Position.X > (LevelWidth * Constants.Screen.TileSize) - GC.Camera.Width) {
     GC.Camera.X = (LevelWidth * Constants.Screen.TileSize) - GC.Camera.Width;
}
if (GC.Camera.Position.Y < 0) {
     GC.Camera.Y = 0;
}
else if (GC.Camera.Position.Y > CameraYMax) {
     GC.Camera.Y = CameraYMax;
}
```

Don't worry about the specific vars in this example. The point is that we can get and set the camera position as well as some other attributes about it.

One annoying detail - the `Camera.Position` vector is get only, but there are `X` and `Y` properties that can be used for getting and setting. I'm not using one over the other, but we should discuss some standards or changes to this class if necessary.